### PR TITLE
feat(gifts): added payment cancelation flow

### DIFF
--- a/Guest-Website/src/router/index.ts
+++ b/Guest-Website/src/router/index.ts
@@ -37,9 +37,19 @@ const routes = [
       console.log('🚦 Route guard triggered for payment validation', to.path )
       const giftStore = await lazyStoreAccess.getGiftStore()
       const guestToken = to.params.token as string
+
+      if(to.query && to.query.action === 'cancel' && to.query.reference) {
+        console.log('Payment was cancelled for reference:', to.query.reference)
+        const reference = to.query.reference as string
+
+        console.log('Removing guest gift associated with cancelled payment')
+        await giftStore.removeGuestGift(guestToken, reference)
+
+        console.log('Redirecting back to main website after cancellation')
+        return { name: 'main-website', replace: true }
+      }
       
       await giftStore.fetchGuestGifts(guestToken)
-
       return true
     }
   },

--- a/Guest-Website/src/stores/gift.ts
+++ b/Guest-Website/src/stores/gift.ts
@@ -354,6 +354,31 @@ export const useGiftStore = defineStore('gift', () => {
     guestStorage.saveGuestData(token, { guestGift: gifts.value })
   }
 
+  const removeGuestGift = async (token: string, ref: string) => {
+    console.log('Removing guest gift with ref:', ref)
+    if(!token || !ref) {
+      console.error('token and reference is required to remove gift from database')
+      return
+    }
+
+    try {
+      const { data: res, error: err } = await supabase
+        .rpc('guest_remove_gift', {
+          auth_token: token,
+          item_reference: ref
+        })
+
+      if (err) {
+        console.error('Supabase RPC error:', err)
+        throw err
+      }
+
+      console.log('Gift removed from database successfully:', res)
+    } catch (err) {
+      console.error('Error removing gift:', err)
+    }
+  }
+
   return {
     // States
     gifts,
@@ -383,6 +408,7 @@ export const useGiftStore = defineStore('gift', () => {
     setSelectedGiftItem,
     clearGiftSelection,
     setIsPayingFees,
-    setGiftingMode
+    setGiftingMode,
+    removeGuestGift
   }
 })


### PR DESCRIPTION
- Added new function to remove initialized gift from the database when the initialized payment is canceled
- Update the 'initilize-payment' edgefunction with proper redirect
- Added proper cancelation handling in the 'payment validation' route